### PR TITLE
IconUrl property added to SlackMessage

### DIFF
--- a/src/Slack.Webhooks/SlackMessage.cs
+++ b/src/Slack.Webhooks/SlackMessage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Slack.Webhooks
@@ -24,6 +25,10 @@ namespace Slack.Webhooks
         /// Optional emoji displayed with the message
         /// </summary>
         public string IconEmoji { get; set; }
+        /// <summary>
+        /// Optional url for icon displayed with the message
+        /// </summary>
+        public Uri IconUrl { get; set; }
         /// <summary>
         /// Optional override markdown mode. Default: true
         /// </summary>


### PR DESCRIPTION
There was an ```icon_url``` property missing from the ```SlackMessage```.

As they say on the [documentation page](https://api.slack.com/incoming-webhooks)

>You can also override the bot icon either with ```icon_url``` or ```icon_emoji```

Not only the ```icon_emoji``` can be used to customise the picture which is representing the bot.