### PR TITLE
Fix JSON format in PostAsync

### DIFF
--- a/src/Slack.Webhooks/Properties/AssemblyInfo.cs
+++ b/src/Slack.Webhooks/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.6.*")]
-[assembly: AssemblyFileVersion("0.1.6.0")]
+[assembly: AssemblyVersion("0.1.7.*")]
+[assembly: AssemblyFileVersion("0.1.7.0")]

--- a/src/Slack.Webhooks/Slack.Webhooks.nuspec
+++ b/src/Slack.Webhooks/Slack.Webhooks.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Slack.Webhooks</id>
-        <version>0.1.6</version>
+        <version>0.1.7</version>
         <authors>Benn Lazell and contributors</authors>
         <licenseUrl>https://github.com/nerdfury/Slack.Webhooks/blob/master/LICENSE</licenseUrl>
         <iconUrl>http://files.fivedegrees.co.uk/Slack.Webhooks/webhook.png</iconUrl>

--- a/src/Slack.Webhooks/SlackClient.cs
+++ b/src/Slack.Webhooks/SlackClient.cs
@@ -25,7 +25,7 @@ namespace Slack.Webhooks
         {
             if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out _webhookUri))
                 throw new ArgumentException("Please enter a valid Slack webhook url");
-           
+
             if (_webhookUri.Host != VALID_HOST)
                 throw new ArgumentException("Please enter a valid Slack webhook url");
 
@@ -40,10 +40,10 @@ namespace Slack.Webhooks
             var conventionEnum = assembly.GetType("ServiceStack.Text.JsonPropertyConvention") ??
                            assembly.GetType("ServiceStack.Text.PropertyConvention");
             var propertyConvention = jsConfig.GetProperty("PropertyConvention");
-            
+
             var lenient = conventionEnum.GetField("Lenient");
 
-            var enumValue = Enum.ToObject(conventionEnum, (int) lenient.GetValue(conventionEnum));
+            var enumValue = Enum.ToObject(conventionEnum, (int)lenient.GetValue(conventionEnum));
             propertyConvention.SetValue(scope, enumValue, null);
         }
 
@@ -55,7 +55,7 @@ namespace Slack.Webhooks
                 scope.EmitLowercaseUnderscoreNames = true;
                 scope.IncludeNullValues = false;
                 SetPropertyConvention(scope);
-                
+
                 request.AddParameter("payload", JsonSerializer.SerializeToString(slackMessage));
 
                 try
@@ -70,12 +70,12 @@ namespace Slack.Webhooks
             }
         }
 
-		public bool PostToChannels(SlackMessage message, IEnumerable<string> channels)
-		{
-			return channels.DefaultIfEmpty(message.Channel)
-					.Select(message.Clone)
-					.Select(Post).All(r => r);
-		}
+        public bool PostToChannels(SlackMessage message, IEnumerable<string> channels)
+        {
+            return channels.DefaultIfEmpty(message.Channel)
+                    .Select(message.Clone)
+                    .Select(Post).All(r => r);
+        }
 
 #if NET40
         public IEnumerable<Task<IRestResponse>> PostToChannelsAsync(SlackMessage message, IEnumerable<string> channels)
@@ -88,8 +88,14 @@ namespace Slack.Webhooks
         public Task<IRestResponse> PostAsync(SlackMessage slackMessage)
         {
             var request = new RestRequest(_webhookUri.PathAndQuery, Method.POST);
+            using (var scope = JsConfig.BeginScope())
+            {
+                scope.EmitLowercaseUnderscoreNames = true;
+                scope.IncludeNullValues = false;
+                SetPropertyConvention(scope);
 
-            request.AddParameter("payload", JsonSerializer.SerializeToString(slackMessage));
+                request.AddParameter("payload", JsonSerializer.SerializeToString(slackMessage));
+            }
 
             return ExecuteTaskAsync(request);
         }


### PR DESCRIPTION
Currently, the payload is getting `Text="..."` instead of `text="..."` which is causing `PostAsync` requests to fail. This copies the json formatting options from `Post` and uses them.