### PR TITLE
Add timeout control to SlackClient

### DIFF
--- a/src/Slack.Webhooks.Tests/SlackClientTests.cs
+++ b/src/Slack.Webhooks.Tests/SlackClientTests.cs
@@ -44,5 +44,15 @@ namespace Slack.Webhooks.Tests
             Assert.False(result);
         }
 
+        [Fact]
+        public void SlackClient_should_remember_timeout()
+        {
+            const string webserviceurl = "https://hooks.slack.com/invalid";
+            var timeoutSeconds = 2;
+            var client = new SlackClient(webserviceurl, timeoutSeconds);
+
+            Assert.Equal(timeoutSeconds * 1000, client.TimeoutMs);
+        }
+
     }
 }

--- a/src/Slack.Webhooks/Properties/AssemblyInfo.cs
+++ b/src/Slack.Webhooks/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.1.8.*")]
 [assembly: AssemblyFileVersion("0.1.8.0")]
+
+[assembly: InternalsVisibleTo("Slack.Webhooks.Tests")]

--- a/src/Slack.Webhooks/Properties/AssemblyInfo.cs
+++ b/src/Slack.Webhooks/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.6.*")]
-[assembly: AssemblyFileVersion("0.1.6.0")]
+[assembly: AssemblyVersion("0.1.8.*")]
+[assembly: AssemblyFileVersion("0.1.8.0")]

--- a/src/Slack.Webhooks/Slack.Webhooks.nuspec
+++ b/src/Slack.Webhooks/Slack.Webhooks.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Slack.Webhooks</id>
-        <version>0.1.6</version>
+        <version>0.1.8</version>
         <authors>Benn Lazell and contributors</authors>
         <licenseUrl>https://github.com/nerdfury/Slack.Webhooks/blob/master/LICENSE</licenseUrl>
         <iconUrl>http://files.fivedegrees.co.uk/Slack.Webhooks/webhook.png</iconUrl>

--- a/src/Slack.Webhooks/SlackClient.cs
+++ b/src/Slack.Webhooks/SlackClient.cs
@@ -21,7 +21,7 @@ namespace Slack.Webhooks
         private const string VALID_HOST = "hooks.slack.com";
         private const string POST_SUCCESS = "ok";
 
-        public SlackClient(string webhookUrl)
+        public SlackClient(string webhookUrl, int timeoutSeconds = 100)
         {
             if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out _webhookUri))
                 throw new ArgumentException("Please enter a valid Slack webhook url");
@@ -31,6 +31,7 @@ namespace Slack.Webhooks
 
             var baseUrl = _webhookUri.GetLeftPart(UriPartial.Authority);
             _restClient = new RestClient(baseUrl);
+            _restClient.Timeout = timeoutSeconds * 1000;
         }
 
         private void SetPropertyConvention(JsConfigScope scope)

--- a/src/Slack.Webhooks/SlackClient.cs
+++ b/src/Slack.Webhooks/SlackClient.cs
@@ -21,6 +21,11 @@ namespace Slack.Webhooks
         private const string VALID_HOST = "hooks.slack.com";
         private const string POST_SUCCESS = "ok";
 
+        /// <summary>
+        /// Returns the RestClient's current Timeout value.
+        /// </summary>
+        internal int TimeoutMs { get { return _restClient.Timeout; } }
+
         public SlackClient(string webhookUrl, int timeoutSeconds = 100)
         {
             if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out _webhookUri))


### PR DESCRIPTION
This simply adds the ability for the consumer to control the timeout on the client. 

Also adds a test to verify that setting it actually works.