### PR TITLE
Add an ISlackClient interface to make mocking easier

### DIFF
--- a/src/Slack.Webhooks/ISlackClient.cs
+++ b/src/Slack.Webhooks/ISlackClient.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+#if NET40
+using System.Threading.Tasks;
+using RestSharp;
+#endif
+
+namespace Slack.Webhooks
+{
+	public interface ISlackClient
+	{
+		bool Post(SlackMessage slackMessage);
+		bool PostToChannels(SlackMessage message, IEnumerable<string> channels);
+#if NET40
+		Task<IRestResponse> PostAsync(SlackMessage slackMessage);
+		IEnumerable<Task<IRestResponse>> PostToChannelsAsync(SlackMessage message, IEnumerable<string> channels);
+#endif
+	}
+}

--- a/src/Slack.Webhooks/Slack.Webhooks.csproj
+++ b/src/Slack.Webhooks/Slack.Webhooks.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Emoji.cs" />
+    <Compile Include="ISlackClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SlackAttachment.cs" />
     <Compile Include="SlackClient.cs" />

--- a/src/Slack.Webhooks/SlackClient.cs
+++ b/src/Slack.Webhooks/SlackClient.cs
@@ -13,7 +13,7 @@ using RestSharp.Extensions;
 
 namespace Slack.Webhooks
 {
-    public class SlackClient
+    public class SlackClient : ISlackClient
     {
         private readonly RestClient _restClient;
         private readonly Uri _webhookUri;


### PR DESCRIPTION
As per issue #26, this adds an interface so that it's easier to mock the SlackClient in tests.