### PR TITLE
Added the response_type to the slack message

### DIFF
--- a/src/Slack.Webhooks/SlackMessage.cs
+++ b/src/Slack.Webhooks/SlackMessage.cs
@@ -14,6 +14,10 @@ namespace Slack.Webhooks
         /// </summary>
         public string Text { get; set; }
         /// <summary>
+        /// Set response to visible to all 'in_channel' or visible to the requester 'ephermeral'
+        /// </summary>
+        public string ResponseType { get; set; }
+        /// <summary>
         /// Optional override of destination channel
         /// </summary>
         public string Channel { get; set; }


### PR DESCRIPTION
As per issues #31 I've added the 'response_type' to the slack message. This enables you to choose whether the response is visible to the channel or only visible to the requester. 