### PR TITLE
Rename Action namespace and class 

### DIFF
--- a/src/Slack.Webhooks/Action/Confirm.cs
+++ b/src/Slack.Webhooks/Action/Confirm.cs
@@ -1,4 +1,4 @@
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     public class Confirm
     {

--- a/src/Slack.Webhooks/Action/DataSource.cs
+++ b/src/Slack.Webhooks/Action/DataSource.cs
@@ -1,4 +1,4 @@
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     public static class DataSource
     {

--- a/src/Slack.Webhooks/Action/Option.cs
+++ b/src/Slack.Webhooks/Action/Option.cs
@@ -1,4 +1,4 @@
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     public class Option
     {

--- a/src/Slack.Webhooks/Action/OptionGroup.cs
+++ b/src/Slack.Webhooks/Action/OptionGroup.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     public class OptionGroup
     {

--- a/src/Slack.Webhooks/Action/SlackAction.cs
+++ b/src/Slack.Webhooks/Action/SlackAction.cs
@@ -1,15 +1,15 @@
 using System.Collections.Generic;
 
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     /// <summary>
     /// Slack attachment action. An attachment can have zero or more actions.
     /// </summary>
-    public class Action
+    public class SlackAction
     {
-        private string _type = SlackAction.Type.Button;
-        private string _style = SlackAction.Style.Default;
-        private string _dataSource = SlackAction.DataSource.Static;
+        private string _type = Action.Type.Button;
+        private string _style = Action.Style.Default;
+        private string _dataSource = Action.DataSource.Static;
 
         /// <summary>
         /// Provide a string to give this specific action a name.   

--- a/src/Slack.Webhooks/Action/Style.cs
+++ b/src/Slack.Webhooks/Action/Style.cs
@@ -1,4 +1,4 @@
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     public static class Style
     {

--- a/src/Slack.Webhooks/Action/Type.cs
+++ b/src/Slack.Webhooks/Action/Type.cs
@@ -1,4 +1,4 @@
-namespace Slack.Webhooks.SlackAction
+namespace Slack.Webhooks.Action
 {
     public static class Type
     {

--- a/src/Slack.Webhooks/Slack.Webhooks.csproj
+++ b/src/Slack.Webhooks/Slack.Webhooks.csproj
@@ -60,16 +60,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Action\Confirm.cs" />
+    <Compile Include="Action\DataSource.cs" />
+    <Compile Include="Action\Option.cs" />
+    <Compile Include="Action\OptionGroup.cs" />
+    <Compile Include="Action\SlackAction.cs" />
+    <Compile Include="Action\Style.cs" />
+    <Compile Include="Action\Type.cs" />
     <Compile Include="Emoji.cs" />
     <Compile Include="ISlackClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SlackAction\Action.cs" />
-    <Compile Include="SlackAction\Confirm.cs" />
-    <Compile Include="SlackAction\DataSource.cs" />
-    <Compile Include="SlackAction\Option.cs" />
-    <Compile Include="SlackAction\OptionGroup.cs" />
-    <Compile Include="SlackAction\Style.cs" />
-    <Compile Include="SlackAction\Type.cs" />
     <Compile Include="SlackAttachment.cs" />
     <Compile Include="SlackClient.cs" />
     <Compile Include="SlackField.cs" />

--- a/src/Slack.Webhooks/SlackAttachment.cs
+++ b/src/Slack.Webhooks/SlackAttachment.cs
@@ -77,6 +77,6 @@ namespace Slack.Webhooks
         /// <summary>
         /// The actions you provide will be rendered as message buttons or menus to users.
         /// </summary>
-        public List<SlackAction.Action> Actions { get; set; }
+        public List<Action.SlackAction> Actions { get; set; }
     }
 }


### PR DESCRIPTION
Rename namespace from 'Slack.Webhooks.SlackAction' to 'Slack.Webhooks.Action'. 
Rename class from Action to SlackAction

This will avoid System.Action conflict