### PR TITLE
Add support for other services that support Slack-like webhooks

### DIFF
--- a/src/Slack.Webhooks.Tests/SlackClientTests.cs
+++ b/src/Slack.Webhooks.Tests/SlackClientTests.cs
@@ -18,6 +18,12 @@ namespace Slack.Webhooks.Tests
         }
 
         [Fact]
+        public void SlackClient_should_not_throw_exception_if_validateHost_is_false()
+        {
+            Assert.DoesNotThrow(() => new SlackClient("https://org.ryver.com/application/webhook/abcdef123456", validateHost: false));
+        }
+
+        [Fact]
         public void SlackClient_should_throw_exception_if_valid_url_not_given()
         {
             Assert.Throws<ArgumentException>(() => new SlackClient("[/]dodgy_url!@.slack.com"));

--- a/src/Slack.Webhooks/SlackClient.cs
+++ b/src/Slack.Webhooks/SlackClient.cs
@@ -26,12 +26,12 @@ namespace Slack.Webhooks
         /// </summary>
         internal int TimeoutMs { get { return _restClient.Timeout; } }
 
-        public SlackClient(string webhookUrl, int timeoutSeconds = 100)
+        public SlackClient(string webhookUrl, int timeoutSeconds = 100, bool validateHost = true)
         {
             if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out _webhookUri))
                 throw new ArgumentException("Please enter a valid Slack webhook url");
 
-            if (_webhookUri.Host != VALID_HOST)
+            if (validateHost && _webhookUri.Host != VALID_HOST)
                 throw new ArgumentException("Please enter a valid Slack webhook url");
 
             var baseUrl = _webhookUri.GetLeftPart(UriPartial.Authority);


### PR DESCRIPTION
[Ryver](http://support.ryver.com/api-incoming-webhooks/) and [MatterMost](https://docs.mattermost.com/developer/webhooks-incoming.html#slack-compatibility) (and others) support Slack-style webhooks.

Added option to disable hostname checks so that `SlackClient` can be used with those services.