### PR TITLE
Emoji is optional.

### DIFF
--- a/src/Slack.Webhooks/SlackMessage.cs
+++ b/src/Slack.Webhooks/SlackMessage.cs
@@ -29,7 +29,7 @@ namespace Slack.Webhooks
         /// <summary>
         /// Optional emoji displayed with the message
         /// </summary>
-        public Emoji IconEmoji { get; set; }
+        public Emoji? IconEmoji { get; set; }
         /// <summary>
         /// Optional url for icon displayed with the message
         /// </summary>


### PR DESCRIPTION
The Emoji of a SlackMessage should be optional. Otherwise, the default value for the Emoji-enum (PlusOne) will be used for every message.
With a nullable enum, the default value will be `null`. This way, the avatar of the user will be used in Slack.